### PR TITLE
Remove baseUrl from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,


### PR DESCRIPTION
The baseUrl configuration was removed from the TypeScript compiler options. This change simplifies the TypeScript configuration by removing an explicit base URL setting that was previously defined but is no longer needed for the project's build setup.